### PR TITLE
Add `allow_issue_writing` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ You do not have to create a dedicated token. Make sure to use the GitHub's defau
 **Optional** By default ZAP Docker container will fail with an [exit code](https://github.com/zaproxy/zaproxy/blob/efb404d38280dc9ecf8f88c9b0c658385861bdcf/docker/zap-full-scan.py#L31), 
 if it identifies any alerts. Set this option to `true` if you want to fail the status of the GitHub Scan if ZAP identifies any alerts during the scan.
 
+### `allow_issue_writing`
+
+**Optional** Set to `false` if you don't want to create Github issues for the alerts. Defaults to `true`.
+
 ## Example usage
 
 ** Basic **

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'The action status will be set to fail if ZAP identifies any alerts during the full scan'
     required: false
     default: false
+  allow_issue_writing:
+    description: 'Whether Github issues should be created or not'
+    required: false
+    default: true
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ async function run() {
         let cmdOptions = core.getInput('cmd_options');
         let issueTitle = core.getInput('issue_title');
         let failAction = core.getInput('fail_action');
+        let allowIssueWriting = core.getInput('allow_issue_writing');
 
         if (!(String(failAction).toLowerCase() === 'true' || String(failAction).toLowerCase() === 'false')) {
             console.log('[WARNING]: \'fail_action\' action input should be either \'true\' or \'false\'');
@@ -58,7 +59,7 @@ async function run() {
                 console.log('Scanning process completed, starting to analyze the results!')
             }
         }
-        await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName);
+        await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName, allowIssueWriting);
     } catch (error) {
         core.setFailed(error.message);
     }


### PR DESCRIPTION
The option `allow_issue_writing` can be used to control whether github issues will be created or not.